### PR TITLE
client/build-matrix

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -15,19 +15,32 @@ jobs:
         go-version: ^1.13
       id: go
 
-    # Install the dependencies of pkg-config and luajit.
+    # Install the dependencies of pkg-config.
     - name: Install dependencies
       run: |
-        sudo apt update &&
-        sudo apt install pkg-config libluajit-5.1-dev
+        sudo apt update && sudo apt install pkg-config
 
     # Execute checkout to fetch the source code of the project.
     - name: Checkout source code
       uses: actions/checkout@v2
 
+    # Checkout LuaJIT repository for dependencies.
+    - name: Checkout LuaJIT
+      uses: actions/checkout@v2
+      with:
+        path: luajit
+        repository: LuaJIT/LuaJIT
+        ref: v2.1
+
     # Execute build and generate client.so lua file.
     - name: Build
-      run: GO111MODULE=on GOPROXY=https://goproxy.io go build -buildmode="c-shared" -ldflags "-w -s" -o client.so -v ./cmd/client
+      env:
+        PKG_CONFIG_PATH: ${{ github.workspace }}/cmd/client
+        CC: "gcc -fPIC"
+        MAKE: "sudo make"
+      run: |
+        chmod +x ./cmd/client/build.sh &&
+        ./cmd/client/build.sh client.so
 
     # Upload the built artifact as the build result.
     - name: Artifact

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -34,10 +34,11 @@ jobs:
 
     # Execute build and generate client.so lua file.
     - name: Build
+      shell: /bin/bash -e {0}
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/pkgconfig/native
         CC: "gcc -fPIC"
-        MAKE: "sudo make"
+        MAKE: "make"
       run: |
         chmod +x ./cmd/client/build.sh &&
         ./cmd/client/build.sh client.so
@@ -53,6 +54,8 @@ jobs:
   crossbuilds:
     name: Build ${{ matrix.name }}
     runs-on: ubuntu-latest
+
+    # Specify different flavours for cross-building.
     strategy:
       matrix:
         include:
@@ -62,24 +65,62 @@ jobs:
           artifact: client.dll
           aptPackage: gcc-mingw-w64-x86-64
           prefix: x86_64-w64-mingw32
+          luajitRef: "v2.0.5"
+          pkgConfig: "crossbuild"
           cflags: "-fPIC"
           luaHostCC: "gcc -m64"
           luaOs: Windows
           luaTarget: luajit.exe
           goArch: amd64
           goOs: windows
+
         - title: windows-i386
           name: Windows i386
           download: client-windows-i386.dll
           artifact: client.dll
           aptPackage: gcc-mingw-w64-i686
           prefix: i686-w64-mingw32
+          luajitRef: "v2.0.5"
+          pkgConfig: "crossbuild"
           luaHostCC: "gcc -m32"
           cflags: "-march=i686 -fPIC"
           luaOs: Windows
           luaTarget: luajit.exe
           goArch: "386"
           goOs: windows
+
+        - title: android-armeabi-v7a
+          name: Android armv7-a
+          download: client-android-armeabi-v7a.so
+          artifact: client.so
+          aptPackage: ""
+          prefix: arm-linux-androideabi
+          luajitRef: "v2.1.0-beta1"
+          pkgConfig: "android"
+          luaHostCC: "gcc -m32"
+          cflags: "-fPIC"
+          luaOs: Linux
+          luaTarget: luajit
+          goArch: "arm"
+          goOs: linux
+          androidArch: "arm"
+
+        - title: android-arm64-v8a
+          name: Android armv8-a
+          download: client-android-arm64-v8a.so
+          artifact: client.so
+          aptPackage: ""
+          prefix: aarch64-linux-android
+          luajitRef: "v2.1.0-beta1"
+          pkgConfig: "android"
+          luaHostCC: "gcc -m64"
+          cflags: "-fPIC"
+          luaOs: Linux
+          luaTarget: luajit
+          goArch: "arm64"
+          goOs: linux
+          androidArch: "arm64"
+
     steps:
 
     # Setup golang compiler of version Go 1.x
@@ -104,12 +145,23 @@ jobs:
       with:
         path: luajit
         repository: LuaJIT/LuaJIT
-        ref: v2.0.5
+        ref: ${{ matrix.luajitRef }}
+
+    # Install Android NDK if there's android target specified.
+    - name: Install Android NDK
+      if: ${{ matrix.androidArch != null }}
+      uses: ravinderjangra/android-ndk-toolchain-setup@0.2
+      with:
+        api: "21"
+        arch: ${{ matrix.androidArch }}
+        install-location: 'ndk'
+        force: true
 
     # Execute build and generate client.so lua file.
     - name: Build
+      shell: /bin/bash -e {0}
       env:
-        PKG_CONFIG_PATH: ${{ github.workspace }}/pkgconfig/crossbuild
+        PKG_CONFIG_PATH: ${{ github.workspace }}/pkgconfig/${{ matrix.pkgConfig }}
         HOST_CC: ${{ matrix.luaHostCC }}
         XCFLAGS: ${{ matrix.cflags }}
         CROSS: "${{ matrix.prefix }}-"
@@ -117,7 +169,7 @@ jobs:
         FILE_T: ${{ matrix.luaTarget }}
         CC: "${{ matrix.prefix }}-gcc ${{ matrix.cflags }}"
         CXX: "${{ matrix.prefix }}-g++ ${{ matrix.cflags }}"
-        MAKE: "sudo make --trace"
+        MAKE: "make --trace"
         GOOS: ${{ matrix.goOs }}
         GOARCH: ${{ matrix.goArch }}
       run: |

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -49,10 +49,37 @@ jobs:
           name: client-linux.so
           path: client.so
 
-  # Build client.dll using cross build method.
-  build-windows:
-    name: Build Windows
+  # Cross building dynamic libraries on different platforms.
+  crossbuilds:
+    name: Build ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - title: windows-x86-64
+          name: Windows x86-64
+          download: client-windows-x86-64.dll
+          artifact: client.dll
+          aptPackage: gcc-mingw-w64-x86-64
+          prefix: x86_64-w64-mingw32
+          cflags: "-fPIC"
+          luaHostCC: "gcc -m64"
+          luaOs: Windows
+          luaTarget: luajit.exe
+          goArch: amd64
+          goOs: windows
+        - title: windows-i386
+          name: Windows i386
+          download: client-windows-i386.dll
+          artifact: client.dll
+          aptPackage: gcc-mingw-w64-i686
+          prefix: i686-w64-mingw32
+          luaHostCC: "gcc -m32"
+          cflags: "-march=i686 -fPIC"
+          luaOs: Windows
+          luaTarget: luajit.exe
+          goArch: "386"
+          goOs: windows
     steps:
 
     # Setup golang compiler of version Go 1.x
@@ -65,7 +92,7 @@ jobs:
     # Install the dependencies of pkg-config and mingw64-w64.
     - name: Install dependencies
       run: |
-        sudo apt update && sudo apt install pkg-config gcc-mingw-w64-x86-64 gcc-multilib
+        sudo apt update && sudo apt install pkg-config ${{ matrix.aptPackage }} gcc-multilib
 
     # Execute checkout to fetch the source code of the project.
     - name: Checkout source code
@@ -83,21 +110,23 @@ jobs:
     - name: Build
       env:
         PKG_CONFIG_PATH: ${{ github.workspace }}/pkgconfig/crossbuild
-        HOST_CC: "gcc -m64"
-        XCFLAGS: "-fPIC"
-        CROSS: "x86_64-w64-mingw32-"
-        TARGET_SYS: "Windows"
-        FILE_T: "luajit.exe"
-        CC: "x86_64-w64-mingw32-gcc -fPIC"
+        HOST_CC: ${{ matrix.luaHostCC }}
+        XCFLAGS: ${{ matrix.cflags }}
+        CROSS: "${{ matrix.prefix }}-"
+        TARGET_SYS: ${{ matrix.luaOs }}
+        FILE_T: ${{ matrix.luaTarget }}
+        CC: "${{ matrix.prefix }}-gcc ${{ matrix.cflags }}"
+        CXX: "${{ matrix.prefix }}-g++ ${{ matrix.cflags }}"
         MAKE: "sudo make --trace"
-        GOOS: "windows"
+        GOOS: ${{ matrix.goOs }}
+        GOARCH: ${{ matrix.goArch }}
       run: |
         chmod +x ./cmd/client/build.sh &&
-        ./cmd/client/build.sh client.dll
+        ./cmd/client/build.sh ${{ matrix.artifact }}
 
     # Upload the built artifact as the build result.
     - name: Artifact
       uses: actions/upload-artifact@v2
       with:
-          name: client-windows.dll
-          path: client.dll
+          name: ${{ matrix.download }}
+          path: ${{ matrix.artifact }}

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: 1.12
       id: go
 
     # Install the dependencies of pkg-config.
@@ -30,12 +30,12 @@ jobs:
       with:
         path: luajit
         repository: LuaJIT/LuaJIT
-        ref: v2.1
+        ref: v2.0.5
 
     # Execute build and generate client.so lua file.
     - name: Build
       env:
-        PKG_CONFIG_PATH: ${{ github.workspace }}/cmd/client
+        PKG_CONFIG_PATH: ${{ github.workspace }}/pkgconfig/native
         CC: "gcc -fPIC"
         MAKE: "sudo make"
       run: |
@@ -49,11 +49,23 @@ jobs:
           name: client-linux.so
           path: client.so
 
-  # Build client.dll under windows operating system.
+  # Build client.dll using cross build method.
   build-windows:
     name: Build Windows
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
+
+    # Setup golang compiler of version Go 1.x
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.12
+      id: go
+
+    # Install the dependencies of pkg-config and mingw64-w64.
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install pkg-config gcc-mingw-w64-x86-64 gcc-multilib
 
     # Execute checkout to fetch the source code of the project.
     - name: Checkout source code
@@ -65,19 +77,23 @@ jobs:
       with:
         path: luajit
         repository: LuaJIT/LuaJIT
-        ref: v2.1
+        ref: v2.0.5
 
-    # Prepare MinGW environment for connector building.
-    - name: Checkout MinGW
-      uses: eine/setup-msys2@v0
-      with:
-        msystem: MSYS
-        update: true
-
-    # Execute build and generate the techmino.client.dll lua file.
+    # Execute build and generate client.so lua file.
     - name: Build
-      shell: msys2 {0}
-      run: ./cmd/client/mingw64.sh
+      env:
+        PKG_CONFIG_PATH: ${{ github.workspace }}/pkgconfig/crossbuild
+        HOST_CC: "gcc -m64"
+        XCFLAGS: "-fPIC"
+        CROSS: "x86_64-w64-mingw32-"
+        TARGET_SYS: "Windows"
+        FILE_T: "luajit.exe"
+        CC: "x86_64-w64-mingw32-gcc -fPIC"
+        MAKE: "sudo make --trace"
+        GOOS: "windows"
+      run: |
+        chmod +x ./cmd/client/build.sh &&
+        ./cmd/client/build.sh client.dll
 
     # Upload the built artifact as the build result.
     - name: Artifact

--- a/cmd/client/build.sh
+++ b/cmd/client/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Initialize the environments when they are absent.
+if [ "$MAKE" == "" ]; then export MAKE=make; fi
+if [ "$CC" == "" ]; then export CC=gcc; fi
+if [ "$CXX" == "" ]; then export CXX=g++; fi
+if [ "$GOOS" == "" ]; then export GOOS=linux; fi
+if [ "$GOARCH" == "" ]; then export GOARCH=amd64; fi
+
+# Build the LuaJIT (checked-out in the workflow).
+echo "Build LuaJIT for link dependencies"
+cd luajit
+$MAKE BUILDMODE=static CC="$CC" clean all install
+cd -
+
+# Build the client connector archive.
+echo "Build the TechminoOnline client connector"
+CGO_ENABLED=1 GO111MODULE=on GOPROXY=https://goproxy.io \
+	go build -ldflags '-w -s' -buildmode="c-shared" \
+	-o "$1" -v ./cmd/client

--- a/cmd/client/build.sh
+++ b/cmd/client/build.sh
@@ -1,27 +1,54 @@
 #!/bin/bash
 
+# Explicitly assign the /builds/luajit as install
+# directory for luajit.
+export PREFIX=/builds/luajit
+sudo mkdir -p $PREFIX
+sudo chmod a+rwx $PREFIX
+
 # Initialize the environments when they are absent.
 if [ "$MAKE" == "" ]; then export MAKE=make; fi
 if [ "$CC" == "" ]; then export CC=gcc; fi
 if [ "$CXX" == "" ]; then export CXX=g++; fi
 if [ "$GOOS" == "" ]; then export GOOS=linux; fi
 if [ "$GOARCH" == "" ]; then export GOARCH=amd64; fi
+export CC="$CC -L$PWD"
+export CXX="$CC -L$PWD"
+
+# Extraly add $PWD/ndk/bin to the path if there's
+# such directory present.
+if [ -d "$PWD/ndk/bin" ]; then
+  export PATH="$PATH:$PWD/ndk/bin";
+
+  # XXX(aegisudio): there's a setting in go that
+  # enforces a specification of -pthread, which
+  # causes a compile error. To negate the error,
+  # we create a pseudo archive for it.
+  ar m $PWD/libpthread.a
+fi
+
+# Print out variables for debugging purpose.
+echo "Current Shell \$PATH: $PATH"
+echo "Current Go Environment: "
+CGO_ENABLED=1 GO111MODULE=on go env
 
 # Build the LuaJIT (checked-out in the workflow).
 echo "Build LuaJIT for link dependencies"
 cd luajit
 if [ "$HOST_CC" == "" ]; then
-$MAKE BUILDMODE=static CC="$CC" clean all install
+$MAKE BUILDMODE=static CC="$CC" \
+      PREFIX=/builds/luajit clean all install
 else
 $MAKE BUILDMODE=static HOST_CC="$HOST_CC" \
       XCFLAGS+="$XCFLAGS" CROSS="$CROSS" \
       TARGET_SYS="$TARGET_SYS" FILE_T="$FILE_T" \
-      clean all install
+      PREFIX=/builds/luajit clean all install
 fi
 cd -
 
 # Build the client connector archive.
 echo "Build the TechminoOnline client connector"
 CGO_ENABLED=1 GO111MODULE=on GOPROXY=https://goproxy.io \
-	go build -ldflags '-w -s' -buildmode="c-shared" \
-	-o "$1" -v ./cmd/client
+  go build -x -ldflags "-w -s -extldflags \"-L$PWD\"" \
+  -buildmode="c-shared" -o "$1" -v \
+  -tags 'osusergo netgo' ./cmd/client

--- a/cmd/client/build.sh
+++ b/cmd/client/build.sh
@@ -10,7 +10,14 @@ if [ "$GOARCH" == "" ]; then export GOARCH=amd64; fi
 # Build the LuaJIT (checked-out in the workflow).
 echo "Build LuaJIT for link dependencies"
 cd luajit
+if [ "$HOST_CC" == "" ]; then
 $MAKE BUILDMODE=static CC="$CC" clean all install
+else
+$MAKE BUILDMODE=static HOST_CC="$HOST_CC" \
+      XCFLAGS+="$XCFLAGS" CROSS="$CROSS" \
+      TARGET_SYS="$TARGET_SYS" FILE_T="$FILE_T" \
+      clean all install
+fi
 cd -
 
 # Build the client connector archive.

--- a/cmd/client/luajit.pc
+++ b/cmd/client/luajit.pc
@@ -1,0 +1,27 @@
+# This file is required by linux specific build only.
+
+# Package information for LuaJIT to be used by pkg-config.
+majver=2
+minver=1
+relver=0
+version=${majver}.${minver}.${relver}-beta3
+abiver=5.1
+
+prefix=/usr/local
+multilib=lib
+exec_prefix=${prefix}
+libdir=${exec_prefix}/${multilib}
+libname=luajit-${abiver}
+includedir=${prefix}/include/luajit-${majver}.${minver}
+
+INSTALL_LMOD=${prefix}/share/lua/${abiver}
+INSTALL_CMOD=${prefix}/${multilib}/lua/${abiver}
+
+Name: LuaJIT
+Description: Just-in-time compiler for Lua
+URL: http://luajit.org
+Version: ${version}
+Requires:
+Libs: -L${libdir} -l${libname} -lm -ldl
+Cflags: -I${includedir}
+LDFLAGS: -Wl,-E

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -13,7 +13,8 @@ LUALIB_API int luaopen_client(lua_State* L) {
 		{ "wsraw", luatc_wsraw },
 		{ NULL, NULL },
 	};
-	luaL_newlib(L, regs);
+    lua_createtable(L, 0, 0);
+	luaL_register(L, NULL, regs);
 	return 1;
 }
 */

--- a/cmd/client/mingw64.sh
+++ b/cmd/client/mingw64.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 set -e
-PATH="/mingw64/bin:$PATH"
-GOROOT="/mingw64/lib/go"
+export PATH="/mingw64/bin:$PATH"
+export GOROOT="/mingw64/lib/go"
 
 # Install MinGW build packages dependencies.
 echo "Install MinGW depdencies using MinGW pacman"
@@ -11,15 +11,8 @@ pacman -S --noconfirm mingw-w64-x86_64-gcc \
                       mingw-w64-x86_64-go \
                       mingw-w64-x86_64-pkg-config
 
-# Build the LuaJIT (checked-out in the workflow).
-echo "Build LuaJIT for link dependencies"
-cd luajit
-mingw32-make BUILDMODE=static clean all install
-cd -
-
-# Build the client connector archive.
-echo "Build the TechminoOnline client connector"
-PKG_CONFIG_PATH="/usr/local/lib/pkgconfig" \
-GO111MODULE=on GOPROXY=https://goproxy.io go build \
-	-ldflags '-w -s' -buildmode="c-shared" \
-	-o client.dll -v ./cmd/client
+# Setup environment and execute the build shell.
+export MAKE=mingw32-make
+export GOOS=windows
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
+$(dirname $0)/build.sh client.dll

--- a/pkgconfig/android/luajit.pc
+++ b/pkgconfig/android/luajit.pc
@@ -2,9 +2,9 @@
 
 # Package information for LuaJIT to be used by pkg-config.
 majver=2
-minver=0
-relver=5
-version=${majver}.${minver}.${relver}-beta3
+minver=1
+relver=0
+version=${majver}.${minver}.${relver}-beta1
 abiver=5.1
 
 prefix=/builds/luajit

--- a/pkgconfig/crossbuild/luajit.pc
+++ b/pkgconfig/crossbuild/luajit.pc
@@ -2,8 +2,8 @@
 
 # Package information for LuaJIT to be used by pkg-config.
 majver=2
-minver=1
-relver=0
+minver=0
+relver=5
 version=${majver}.${minver}.${relver}-beta3
 abiver=5.1
 
@@ -22,6 +22,6 @@ Description: Just-in-time compiler for Lua
 URL: http://luajit.org
 Version: ${version}
 Requires:
-Libs: -L${libdir} -l${libname} -lm -ldl
+Libs: -L${libdir} -l${libname} -lm
 Cflags: -I${includedir}
 LDFLAGS: -Wl,-E

--- a/pkgconfig/native/luajit.pc
+++ b/pkgconfig/native/luajit.pc
@@ -1,0 +1,27 @@
+# This file is required by linux specific build only.
+
+# Package information for LuaJIT to be used by pkg-config.
+majver=2
+minver=0
+relver=5
+version=${majver}.${minver}.${relver}-beta3
+abiver=5.1
+
+prefix=/usr/local
+multilib=lib
+exec_prefix=${prefix}
+libdir=${exec_prefix}/${multilib}
+libname=luajit-${abiver}
+includedir=${prefix}/include/luajit-${majver}.${minver}
+
+INSTALL_LMOD=${prefix}/share/lua/${abiver}
+INSTALL_CMOD=${prefix}/${multilib}/lua/${abiver}
+
+Name: LuaJIT
+Description: Just-in-time compiler for Lua
+URL: http://luajit.org
+Version: ${version}
+Requires:
+Libs: -L${libdir} -l${libname} -lm -ldl
+Cflags: -I${includedir}
+LDFLAGS: -Wl,-E

--- a/pkgconfig/native/luajit.pc
+++ b/pkgconfig/native/luajit.pc
@@ -7,7 +7,7 @@ relver=5
 version=${majver}.${minver}.${relver}-beta3
 abiver=5.1
 
-prefix=/usr/local
+prefix=/builds/luajit
 multilib=lib
 exec_prefix=${prefix}
 libdir=${exec_prefix}/${multilib}


### PR DESCRIPTION
- Add build matrix support for building different client binaries.
- Support building binaries for Windows (x86_64, i386), Linux (x86_64) and Android.